### PR TITLE
Return null on unsupported history requests

### DIFF
--- a/QuantConnect.BybitBrokerage.Tests/BybitBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BybitBrokerage.Tests/BybitBrokerageHistoryProviderTests.cs
@@ -24,7 +24,6 @@ using QuantConnect.Logging;
 using QuantConnect.Securities;
 using QuantConnect.Data.Market;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Lean.Engine.HistoricalData;
 
 namespace QuantConnect.BybitBrokerage.Tests
 {
@@ -51,6 +50,8 @@ namespace QuantConnect.BybitBrokerage.Tests
         {
             get
             {
+                TestGlobals.Initialize();
+
                 return new[]
                 {
                     // valid
@@ -68,10 +69,8 @@ namespace QuantConnect.BybitBrokerage.Tests
             {
                 return new[]
                 {
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.Bybit),
-                        Resolution.Second, Time.OneMinute, TickType.Trade),
-                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.Bybit),
-                        Resolution.Minute, Time.OneHour, TickType.Quote),
+                    // invalid period, no error, empty result
+                    new TestCaseData(ETHUSDT, Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade),
                 };
             }
         }
@@ -82,79 +81,92 @@ namespace QuantConnect.BybitBrokerage.Tests
             {
                 return new[]
                 {
-                    // invalid period, no error, empty result
-                    new TestCaseData(Symbols.EURUSD, Resolution.Daily, TimeSpan.FromDays(-15), TickType.Trade),
-
                     // invalid symbol, throws "System.ArgumentException : Unknown symbol: XYZ"
                     new TestCaseData(Symbol.Create("XYZ", SecurityType.CryptoFuture, Market.Bybit), Resolution.Daily,
                         TimeSpan.FromDays(15), TickType.Trade),
 
                     //invalid security type
                     new TestCaseData(Symbols.AAPL, Resolution.Daily, TimeSpan.FromDays(15), TickType.Trade),
+
+                    // invalid resolution
+                    new TestCaseData(ETHUSDT, Resolution.Second, Time.OneMinute, TickType.Trade),
+
+                    // invalid tick type
+                    new TestCaseData(ETHUSDT, Resolution.Minute, Time.OneHour, TickType.Quote),
+
+                    // invalid market
+                    new TestCaseData(Symbol.Create("ETHUSDT", SecurityType.Crypto, Market.Binance), Resolution.Minute,
+                        Time.OneMinute, TickType.Trade),
+
+                    // invalid resolution for tick type
+                    new TestCaseData(ETHUSDT, Resolution.Tick, TimeSpan.FromDays(15), TickType.OpenInterest),
+                    new TestCaseData(ETHUSDT, Resolution.Minute, TimeSpan.FromDays(15), TickType.OpenInterest),
                 };
             }
         }
-
 
         [Test]
         [TestCaseSource(nameof(ValidHistory))]
         public virtual void GetsHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
         {
-            BaseHistoryTest(_brokerage, symbol, resolution, period, tickType, false);
+            BaseHistoryTest(_brokerage, symbol, resolution, period, tickType, false, false);
         }
 
         [Test]
         [TestCaseSource(nameof(NoHistory))]
-        [TestCaseSource(nameof(InvalidHistory))]
         public virtual void GetEmptyHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
         {
-            BaseHistoryTest(_brokerage, symbol, resolution, period, tickType, true);
+            BaseHistoryTest(_brokerage, symbol, resolution, period, tickType, true, false);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InvalidHistory))]
+        public virtual void ReturnsNullOnInvalidHistoryRequest(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
+        {
+            BaseHistoryTest(_brokerage, symbol, resolution, period, tickType, false, true);
         }
 
         protected static void BaseHistoryTest(Brokerage brokerage, Symbol symbol, Resolution resolution,
-            TimeSpan period, TickType tickType, bool emptyData)
+            TimeSpan period, TickType tickType, bool emptyData, bool invalidRequest)
         {
-            var historyProvider = new BrokerageHistoryProvider();
-            historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null,
-                null, null, null, null,
-                false, new DataPermissionManager(), null));
-
             var marketHoursDatabase = MarketHoursDatabase.FromDataFolder();
 
             var now = DateTime.UtcNow.AddDays(-1);
-            var requests = new[]
-            {
-                new HistoryRequest(now.Add(-period),
-                    now,
-                    resolution == Resolution.Tick ? typeof(Tick) : typeof(TradeBar),
-                    symbol,
-                    resolution,
-                    marketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType),
-                    marketHoursDatabase.GetDataTimeZone(symbol.ID.Market, symbol, symbol.SecurityType),
-                    resolution,
-                    false,
-                    false,
-                    DataNormalizationMode.Adjusted,
-                    tickType)
-            };
+            var request = new HistoryRequest(now.Add(-period),
+                now,
+                resolution == Resolution.Tick ? typeof(Tick) : typeof(TradeBar),
+                symbol,
+                resolution,
+                marketHoursDatabase.GetExchangeHours(symbol.ID.Market, symbol, symbol.SecurityType),
+                marketHoursDatabase.GetDataTimeZone(symbol.ID.Market, symbol, symbol.SecurityType),
+                resolution,
+                false,
+                false,
+                DataNormalizationMode.Adjusted,
+                tickType);
 
-            var historyArray = historyProvider.GetHistory(requests, TimeZones.Utc).ToArray();
-            foreach (var slice in historyArray)
+            var history = brokerage.GetHistory(request)?.ToList();
+
+            if (invalidRequest)
             {
-                if (resolution == Resolution.Tick)
+                Assert.IsNull(history);
+                return;
+            }
+
+            Assert.IsNotNull(history);
+
+            foreach (var data in history)
+            {
+                if (data is Tick tick)
                 {
-                    foreach (var tick in slice.Ticks[symbol])
-                    {
-                        Log.Trace("{0}: {1} - {2} / {3}", tick.Time.ToStringInvariant("yyyy-MM-dd HH:mm:ss.fff"),
-                            tick.Symbol, tick.BidPrice, tick.AskPrice);
-                    }
+                    Log.Trace("{0}: {1} - {2} / {3}", tick.Time.ToStringInvariant("yyyy-MM-dd HH:mm:ss.fff"),
+                        tick.Symbol, tick.BidPrice, tick.AskPrice);
                 }
-                else if (slice.QuoteBars.TryGetValue(symbol, out var quoteBar))
+                else if (data is QuoteBar quoteBar)
                 {
                     Log.Trace($"QuoteBar: {quoteBar}");
                 }
-                else if (slice.Bars.TryGetValue(symbol, out var bar))
+                else if (data is TradeBar bar)
                 {
                     Log.Trace("{0}: {1} - O={2}, H={3}, L={4}, C={5}", bar.Time, bar.Symbol, bar.Open, bar.High,
                         bar.Low, bar.Close);
@@ -163,25 +175,24 @@ namespace QuantConnect.BybitBrokerage.Tests
 
             if (emptyData)
             {
-                Assert.Zero(historyProvider.DataPointCount);
+                Assert.IsEmpty(history);
             }
             else
             {
-                Assert.Greater(historyProvider.DataPointCount, 0);
-            }
+                Assert.Greater(history.Count, 0);
 
-            if (historyProvider.DataPointCount > 0)
-            {
                 // Ordered by time
-                Assert.That(historyArray, Is.Ordered.By("Time"));
+                Assert.That(history, Is.Ordered.By("Time"));
 
-                // No repeating bars
-                var timesArray = historyArray.Select(x => x.Time).ToArray();
-                Assert.AreEqual(timesArray.Length, timesArray.Distinct().Count());
-
-                foreach (var slice in historyArray)
+                var timesArray = history.Select(x => x.Time).ToArray();
+                if (resolution != Resolution.Tick)
                 {
-                    var data = slice.AllData[0];
+                    // No repeating bars
+                    Assert.AreEqual(timesArray.Length, timesArray.Distinct().Count());
+                }
+
+                foreach (var data in history)
+                {
                     Assert.AreEqual(symbol, data.Symbol);
 
                     if (data.DataType != MarketDataType.Tick)
@@ -191,7 +202,7 @@ namespace QuantConnect.BybitBrokerage.Tests
                 }
 
                 // No missing bars
-                if (resolution != Resolution.Tick && historyProvider.DataPointCount >= 2)
+                if (resolution != Resolution.Tick && history.Count >= 2)
                 {
                     var diff = resolution.ToTimeSpan();
                     for (var i = 1; i < timesArray.Length; i++)
@@ -201,7 +212,7 @@ namespace QuantConnect.BybitBrokerage.Tests
                 }
             }
 
-            Log.Trace("Data points retrieved: " + historyProvider.DataPointCount);
+            Log.Trace("Data points retrieved: " + history.Count);
         }
 
         private Brokerage CreateBrokerage()

--- a/QuantConnect.BybitBrokerage.Tests/BybitFuturesBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BybitBrokerage.Tests/BybitFuturesBrokerageHistoryProviderTests.cs
@@ -48,12 +48,6 @@ namespace QuantConnect.BybitBrokerage.Tests
         }
 
         [Ignore("The brokerage is shared between different product categories, therefore this test is only required in the base class")]
-        public override void GetEmptyHistory(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
-        {
-            base.GetEmptyHistory(symbol, resolution, period, tickType);
-        }
-
-        [Ignore("The brokerage is shared between different product categories, therefore this test is only required in the base class")]
         public override void ReturnsNullOnInvalidHistoryRequest(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
         {
             base.ReturnsNullOnInvalidHistoryRequest(symbol, resolution, period, tickType);

--- a/QuantConnect.BybitBrokerage.Tests/BybitFuturesBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.BybitBrokerage.Tests/BybitFuturesBrokerageHistoryProviderTests.cs
@@ -52,5 +52,11 @@ namespace QuantConnect.BybitBrokerage.Tests
         {
             base.GetEmptyHistory(symbol, resolution, period, tickType);
         }
+
+        [Ignore("The brokerage is shared between different product categories, therefore this test is only required in the base class")]
+        public override void ReturnsNullOnInvalidHistoryRequest(Symbol symbol, Resolution resolution, TimeSpan period, TickType tickType)
+        {
+            base.ReturnsNullOnInvalidHistoryRequest(symbol, resolution, period, tickType);
+        }
     }
 }

--- a/QuantConnect.BybitBrokerage.ToolBox/BybitBrokerageDownloader.cs
+++ b/QuantConnect.BybitBrokerage.ToolBox/BybitBrokerageDownloader.cs
@@ -145,6 +145,10 @@ namespace QuantConnect.BybitBrokerage.ToolBox
                     // Download the data
                     var symbol = downloader.GetSymbol(ticker, securityTypeEnum);
                     var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, fromDate, toDate, tickType: tickTypeEnum));
+                    if (data == null)
+                    {
+                        continue;
+                    }
 
                     // todo how to write open interest data
                     // Save the data (single resolution)

--- a/QuantConnect.BybitBrokerage.ToolBox/BybitBrokerageDownloader.cs
+++ b/QuantConnect.BybitBrokerage.ToolBox/BybitBrokerageDownloader.cs
@@ -65,17 +65,6 @@ namespace QuantConnect.BybitBrokerage.ToolBox
             var endUtc = dataDownloaderGetParameters.EndUtc;
             var tickType = dataDownloaderGetParameters.TickType;
 
-            if (tickType is not (TickType.Trade or TickType.OpenInterest))
-            {
-                return Enumerable.Empty<BaseData>();
-            }
-
-            if (!_symbolMapper.IsKnownLeanSymbol(symbol))
-                throw new ArgumentException($"The ticker {symbol.Value} is not available.");
-
-            if (endUtc < startUtc)
-                throw new ArgumentException("The end date must be greater or equal than the start date.");
-
             var historyRequest = new HistoryRequest(
                 startUtc,
                 endUtc,
@@ -91,8 +80,7 @@ namespace QuantConnect.BybitBrokerage.ToolBox
                 tickType);
 
             var brokerage = CreateBrokerage();
-            var data = brokerage.GetHistory(historyRequest);
-            return data;
+            return brokerage.GetHistory(historyRequest);
         }
 
         /// <summary>

--- a/QuantConnect.BybitBrokerage/BybitBrokerage.cs
+++ b/QuantConnect.BybitBrokerage/BybitBrokerage.cs
@@ -67,6 +67,7 @@ public partial class BybitBrokerage : BaseWebsocketsBrokerage, IDataQueueHandler
     private bool _unsupportedResolutionHistoryLogged;
     private bool _unsupportedTickTypeHistoryLogged;
     private bool _unsupportedResolutionOpenInterestHistoryLogged;
+    private bool _invalidTimeRangeHistoryLogged;
 
     /// <summary>
     /// Order provider
@@ -179,6 +180,18 @@ public partial class BybitBrokerage : BaseWebsocketsBrokerage, IDataQueueHandler
                 _unsupportedTickTypeHistoryLogged = true;
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidTickType",
                     $"{request.TickType} tick type not supported, no history returned"));
+            }
+
+            return null;
+        }
+
+        if (request.StartTimeUtc >= request.EndTimeUtc)
+        {
+            if (!_invalidTimeRangeHistoryLogged)
+            {
+                _invalidTimeRangeHistoryLogged = true;
+                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidDateRange",
+                    "The history request start date must precede the end date, no history returned"));
             }
 
             return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
