### PR TITLE
Fix: working of Data Downloader

### DIFF
--- a/QuantConnect.BybitBrokerage.ToolBox/BybitBrokerageDownloader.cs
+++ b/QuantConnect.BybitBrokerage.ToolBox/BybitBrokerageDownloader.cs
@@ -34,6 +34,9 @@ namespace QuantConnect.Brokerages.Bybit.ToolBox
         private readonly string _market;
         private readonly SymbolPropertiesDatabaseSymbolMapper _symbolMapper;
 
+        public BybitBrokerageDownloader() : this(Market.Bybit)
+        { }
+
         public BybitBrokerageDownloader(string market = Market.Bybit)
         {
             _market = market;
@@ -125,7 +128,7 @@ namespace QuantConnect.Brokerages.Bybit.ToolBox
                 //Load settings from config.json
                 var dataDirectory = Config.Get("data-folder", Globals.DataFolder);
 
-                var downloader =  CreateDownloader(securityTypeEnum,market);
+                var downloader = CreateDownloader(securityTypeEnum, market);
 
                 foreach (var ticker in tickers)
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This pull request addresses an issue with the data downloader for the **Bybit** brokerage plugin of **Lean** environment. The problem stemmed from an exception where the downloader couldn't be initialized due to the absence of a _parameterless_ constructor. To resolve this, I've implemented a parameterless constructor, fixing the bug.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#20 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind this fix is to ensure that the data downloader for **Bybit** follows the expected pattern and behavior set by other brokerage implementations in Lean. By providing a parameterless constructor, we enable smoother initialization of the downloader, eliminating the previously encountered exception.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To validate the fix, I created a dotnet package of `QuantConnect.BybitBrokerage.ToolBox` and locally ran `lean data download` with `--data-provider-historical ByBit`. The test was successful, and I have attached a screenshot for reference.
##### Downloading process 
![1](https://github.com/QuantConnect/Lean.Brokerages.ByBit/assets/45608740/f6c7c076-ee42-4063-a25e-735bb2ea8be0)
##### Keep on disc (compare with screen above)
> Time Zone Conversion: Upon checking the timestamp of the provided screenshot against my local time, I adjusted it to UTC by subtracting three hours.

![image](https://github.com/QuantConnect/Lean.Brokerages.ByBit/assets/45608740/4cfb6bfe-3cf8-4ac0-9df1-83d75d787dab)


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
