### PR TITLE
Skip LinearFutures(USDC Futures)

### DIFF
--- a/QuantConnect.BybitBrokerage.ToolBox/BybitExchangeInfoDownloader.cs
+++ b/QuantConnect.BybitBrokerage.ToolBox/BybitExchangeInfoDownloader.cs
@@ -61,19 +61,19 @@ namespace QuantConnect.Brokerages.Bybit.ToolBox
                     continue;
                 }
 
-                if (symbol.InstrumentInfo.SettleCoin == "USDC")
+                if (string.Equals(symbol.InstrumentInfo.SettleCoin, "USDC", StringComparison.InvariantCultureIgnoreCase))
                 {
                     // Skip USDC perp and future contracts for now, they'll need some more implementation
                     continue;
                 }
 
-                if (symbol.InstrumentInfo.ContractType == "LinearFutures")
+                if (string.Equals(symbol.InstrumentInfo.ContractType, "LinearFutures", StringComparison.InvariantCultureIgnoreCase))
                 {
                     // Skip LinearFutures contracts as they have expiration dates (USDC Futures)
                     continue;
                 }
 
-                if (symbol.InstrumentInfo.ContractType == "InverseFutures")
+                if (string.Equals(symbol.InstrumentInfo.ContractType, "InverseFutures", StringComparison.InvariantCultureIgnoreCase))
                 {
                     // Skip crypto futures that are not perpetual
                     continue;

--- a/QuantConnect.BybitBrokerage.ToolBox/BybitExchangeInfoDownloader.cs
+++ b/QuantConnect.BybitBrokerage.ToolBox/BybitExchangeInfoDownloader.cs
@@ -67,6 +67,12 @@ namespace QuantConnect.Brokerages.Bybit.ToolBox
                     continue;
                 }
 
+                if (symbol.InstrumentInfo.ContractType == "LinearFutures")
+                {
+                    // Skip LinearFutures contracts as they have expiration dates (USDC Futures)
+                    continue;
+                }
+
                 if (symbol.InstrumentInfo.ContractType == "InverseFutures")
                 {
                     // Skip crypto futures that are not perpetual


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Updated the logic to ignore USDC Futures contracts (LinearFutures) in addition to the already ignored USDC contracts from Bybit. This ensures that all USDC-related contracts are excluded for now.  [Source](https://bybit-exchange.github.io/docs/v5/enum#contracttype)

![image](https://github.com/user-attachments/assets/e0b41ffb-4a26-4c83-a93f-0f7a0b322576)


#### Motivation and Context
With this change, the `BybitExchangeInfoDownloader.cs` will now skip USDC Futures contracts (LinearFutures) in addition to the already excluded USDC perpetual contracts. 

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
