### PR TITLE
Enable concurrent order processing

### DIFF
--- a/QuantConnect.BybitBrokerage.Tests/JsonConverters/JsonConverterTests.cs
+++ b/QuantConnect.BybitBrokerage.Tests/JsonConverters/JsonConverterTests.cs
@@ -76,6 +76,10 @@ public class JsonConverterTests
     [TestCase("-1", -1, true)]
     [TestCase("1.333", 1.333, true)]
     [TestCase("1.333", 1.333, false)]
+    [TestCase("9e-8", 0.00000009, true)]
+    [TestCase("1.3117285e+06", 1311728.5, true)]
+    [TestCase("9e-8", 0.00000009, false)]
+    [TestCase("1.3117285e+06", 1311728.5, false)]
     public void BybitDecimalStringConverterTests(string value, decimal expected, bool quote = true)
     {
         var settings = new JsonSerializerSettings
@@ -114,13 +118,6 @@ public class JsonConverterTests
     public void BybitKlineJsonConverterTests(long openTime, decimal open, decimal high, decimal low, decimal close,
         decimal turnover, decimal volume)
     {
-        var settings = new JsonSerializerSettings
-        {
-            Converters = new List<JsonConverter>
-            {
-                new ByBitKlineJsonConverter()
-            }
-        };
         var dataArray = new object[]
         {
             openTime,
@@ -134,7 +131,7 @@ public class JsonConverterTests
         var arrayString = '[' + string.Join(',', dataArray) + ']';
         var jsonString = TestObject<ByBitKLine>.CreateJsonObject(arrayString);
 
-        var kline = JsonConvert.DeserializeObject<TestObject<ByBitKLine>>(jsonString, settings).Value;
+        var kline = JsonConvert.DeserializeObject<TestObject<ByBitKLine>>(jsonString).Value;
 
         Assert.AreEqual(openTime, kline.OpenTime);
         Assert.AreEqual(open, kline.Open);

--- a/QuantConnect.BybitBrokerage/Api/BybitApiClient.cs
+++ b/QuantConnect.BybitBrokerage/Api/BybitApiClient.cs
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 using System;
 using System.Diagnostics;
@@ -29,13 +29,13 @@ namespace QuantConnect.Brokerages.Bybit.Api;
 /// </summary>
 public class BybitApiClient : IDisposable
 {
-    private readonly HMACSHA256 _hmacSha256;
     private readonly string _apiKey;
+    private readonly string _apiSecret;
     private readonly RestClient _restClient;
     private readonly RateGate _rateGate;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="BybitApiClient"/> class 
+    /// Initializes a new instance of the <see cref="BybitApiClient"/> class
     /// </summary>
     /// <param name="apiKey">The api key</param>
     /// <param name="apiSecret">The api secret</param>
@@ -49,7 +49,7 @@ public class BybitApiClient : IDisposable
     {
         _restClient = new RestClient(restApiUrl);
         _apiKey = apiKey;
-        _hmacSha256 = new HMACSHA256(Encoding.UTF8.GetBytes(apiSecret ?? string.Empty));
+        _apiSecret = apiSecret;
         _rateGate = new RateGate(maxRequestsPerSecond, Time.OneSecond);
     }
 
@@ -116,8 +116,8 @@ public class BybitApiClient : IDisposable
     public string Sign(string stringToSign)
     {
         var messageBytes = Encoding.UTF8.GetBytes(stringToSign);
-
-        var computedHash = _hmacSha256.ComputeHash(messageBytes);
+        var key = Encoding.UTF8.GetBytes(_apiSecret ?? string.Empty);
+        var computedHash = HMACSHA256.HashData(key, messageBytes);
         var hex = new StringBuilder(computedHash.Length * 2);
         foreach (var b in computedHash)
         {
@@ -132,7 +132,6 @@ public class BybitApiClient : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _hmacSha256.DisposeSafely();
         _rateGate.DisposeSafely();
     }
 

--- a/QuantConnect.BybitBrokerage/Api/BybitApiClient.cs
+++ b/QuantConnect.BybitBrokerage/Api/BybitApiClient.cs
@@ -30,7 +30,7 @@ namespace QuantConnect.Brokerages.Bybit.Api;
 public class BybitApiClient : IDisposable
 {
     private readonly string _apiKey;
-    private readonly string _apiSecret;
+    private readonly byte[] _apiSecretBytes;
     private readonly RestClient _restClient;
     private readonly RateGate _rateGate;
 
@@ -49,7 +49,7 @@ public class BybitApiClient : IDisposable
     {
         _restClient = new RestClient(restApiUrl);
         _apiKey = apiKey;
-        _apiSecret = apiSecret;
+        _apiSecretBytes = Encoding.UTF8.GetBytes(apiSecret ?? string.Empty);
         _rateGate = new RateGate(maxRequestsPerSecond, Time.OneSecond);
     }
 
@@ -116,8 +116,7 @@ public class BybitApiClient : IDisposable
     public string Sign(string stringToSign)
     {
         var messageBytes = Encoding.UTF8.GetBytes(stringToSign);
-        var key = Encoding.UTF8.GetBytes(_apiSecret ?? string.Empty);
-        var computedHash = HMACSHA256.HashData(key, messageBytes);
+        var computedHash = HMACSHA256.HashData(_apiSecretBytes, messageBytes);
         var hex = new StringBuilder(computedHash.Length * 2);
         foreach (var b in computedHash)
         {

--- a/QuantConnect.BybitBrokerage/Api/BybitApiEndpoint.cs
+++ b/QuantConnect.BybitBrokerage/Api/BybitApiEndpoint.cs
@@ -45,7 +45,7 @@ public abstract class BybitApiEndpoint
             NamingStrategy = new CamelCaseNamingStrategy()
         },
         Converters = new List<JsonConverter>()
-            { new ByBitKlineJsonConverter(), new StringEnumConverter(), new BybitDecimalStringConverter() },
+            { new StringEnumConverter(), new BybitDecimalStringConverter() },
         NullValueHandling = NullValueHandling.Ignore
     };
 
@@ -115,7 +115,7 @@ public abstract class BybitApiEndpoint
             }
 
             var nextCursor = result.NextPageCursor;
-            // Break when the cursor is either empty or the same as the one we just processed 
+            // Break when the cursor is either empty or the same as the one we just processed
             if (string.IsNullOrEmpty(nextCursor) || (parameterDict.TryGetValue("cursor", out var previousCursor) &&
                                                      previousCursor == nextCursor))
             {

--- a/QuantConnect.BybitBrokerage/BybitBrokerage.Messaging.cs
+++ b/QuantConnect.BybitBrokerage/BybitBrokerage.Messaging.cs
@@ -210,8 +210,13 @@ public partial class BybitBrokerage
             var newStatus = ConvertOrderStatus(order.Status);
             if (newStatus == leanOrder.Status) continue;
 
-            if (order is { Status: OrderStatus.Filled, QuantityFilled: not null })
+            if (order is { Status: OrderStatus.Filled })
             {
+                if (order is { QuantityFilled: null })
+                {
+                    continue;
+                }
+
                 if (!_cumulativeFillQuantity.TryGetValue(leanOrder.Id, out var cumulativeFill)
                     || cumulativeFill < order.QuantityFilled.Value)
                 {
@@ -232,53 +237,16 @@ public partial class BybitBrokerage
                 //   "data": [
                 //     {
                 //       "category": "spot",
-                //       "symbol": "BTCUSDT",
-                //       "orderId": "2139617652191356928",
-                //       "orderLinkId": "2139617652191356929",
-                //       "blockTradeId": "",
+                //       "symbol": "BTCUSDT"
                 //       "side": "Buy",
-                //       "positionIdx": 0,
                 //       "orderStatus": "Filled",
-                //       "cancelType": "UNKNOWN",
-                //       "rejectReason": "EC_NoError",
-                //       "timeInForce": "IOC",
-                //       "isLeverage": "0",
-                //       "price": "0",
-                //       "qty": "8.2379800",
-                //       "avgPrice": "82439.8",
                 //       "leavesQty": "0",
                 //       "leavesValue": "0.0764398",
                 //       "cumExecQty": "0.000099",
                 //       "cumExecValue": "8.1615402",
                 //       "cumExecFee": "0.0000000891",
                 //       "orderType": "Market",
-                //       "stopOrderType": "",
-                //       "orderIv": "",
-                //       "triggerPrice": "0.0",
-                //       "takeProfit": "0.0",
-                //       "stopLoss": "0.0",
-                //       "triggerBy": "",
-                //       "tpTriggerBy": "",
-                //       "slTriggerBy": "",
-                //       "triggerDirection": 0,
-                //       "placeType": "",
-                //       "lastPriceOnCreated": "82439.3",
-                //       "closeOnTrigger": false,
-                //       "reduceOnly": false,
-                //       "smpGroup": 0,
-                //       "smpType": "None",
-                //       "smpOrderId": "",
-                //       "slLimitPrice": "0.0",
-                //       "tpLimitPrice": "0.0",
-                //       "marketUnit": "quoteCoin",
-                //       "createdTime": "1769798300228",
-                //       "updatedTime": "1769798300233",
-                //       "feeCurrency": "BTC",
-                //       "slippageTolerance": "",
-                //       "slippageToleranceType": "UNKNOWN",
-                //       "cumFeeDetail": {
-                //         "BTC": "0.0000000891"
-                //       }
+                //       ... rest fields
                 //     }
                 //   ]
                 // }

--- a/QuantConnect.BybitBrokerage/BybitBrokerage.Messaging.cs
+++ b/QuantConnect.BybitBrokerage/BybitBrokerage.Messaging.cs
@@ -229,7 +229,7 @@ public partial class BybitBrokerage
                 // We need to issue the OrderStatus.Filled event
                 // as HandleOrderExecution issued only PartiallyFilled events, and no more events are expected
                 // Order is fully filled, but less than Lean expected, i.e.
-                // Bybit can slightly reduce the order size if it was partially filled initialy, i.e. see json example (cumExecQty, leavesQty, leavesValue)
+                // Bybit can slightly reduce the order size if it was partially filled initialy, see json example (cumExecQty, leavesQty, leavesValue) for the Buy 0.0001 (reduced by the lot size)
                 // {
                 //   "topic": "order",
                 //   "id": "106619370_20000_2021269409",

--- a/QuantConnect.BybitBrokerage/BybitBrokerage.cs
+++ b/QuantConnect.BybitBrokerage/BybitBrokerage.cs
@@ -84,6 +84,11 @@ public partial class BybitBrokerage : BaseWebsocketsBrokerage, IDataQueueHandler
     public override bool IsConnected => _apiClientLazy?.IsValueCreated != true || WebSocket?.IsOpen == true;
 
     /// <summary>
+    /// Enables concurrent processing of messages to and from the brokerage.
+    /// </summary>
+    public override bool ConcurrencyEnabled { get; set; } = true;
+
+    /// <summary>
     /// Parameterless constructor for brokerage
     /// </summary>
     public BybitBrokerage() : base(MarketName)
@@ -244,7 +249,7 @@ public partial class BybitBrokerage : BaseWebsocketsBrokerage, IDataQueueHandler
         _job = job;
         _algorithm = algorithm;
         _aggregator = aggregator;
-        _messageHandler = new BrokerageConcurrentMessageHandler<WebSocketMessage>(OnUserMessage);
+        _messageHandler = new BrokerageConcurrentMessageHandler<WebSocketMessage>(OnUserMessage, ConcurrencyEnabled);
         _symbolMapper = new SymbolPropertiesDatabaseSymbolMapper(MarketName);
         OrderProvider = orderProvider;
 

--- a/QuantConnect.BybitBrokerage/Converters/ByBitKlineJsonConverter.cs
+++ b/QuantConnect.BybitBrokerage/Converters/ByBitKlineJsonConverter.cs
@@ -67,12 +67,12 @@ public class ByBitKlineJsonConverter : JsonConverter<ByBitKLine>
 
         existingValue = existingValue ?? new ByBitKLine();
         existingValue.OpenTime = token[0]!.Value<long>();
-        existingValue.Open = token[1]!.Value<decimal>();
-        existingValue.High = token[2]!.Value<decimal>();
-        existingValue.Low = token[3]!.Value<decimal>();
-        existingValue.Close = token[4]!.Value<decimal>();
-        existingValue.Turnover = token[5]!.Value<decimal>();
-        existingValue.Volume = token[6]!.Value<decimal>();
+        existingValue.Open = token[1]!.ToObject<decimal>(serializer);
+        existingValue.High = token[2]!.ToObject<decimal>(serializer);
+        existingValue.Low = token[3]!.ToObject<decimal>(serializer);
+        existingValue.Close = token[4]!.ToObject<decimal>(serializer);
+        existingValue.Turnover = token[5]!.ToObject<decimal>(serializer);
+        existingValue.Volume = token[6]!.ToObject<decimal>(serializer);
 
 
         return existingValue;

--- a/QuantConnect.BybitBrokerage/Converters/BybitCandleTimeConverter.cs
+++ b/QuantConnect.BybitBrokerage/Converters/BybitCandleTimeConverter.cs
@@ -11,9 +11,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 using System;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace QuantConnect.Brokerages.Bybit.Converters;
@@ -59,7 +60,7 @@ public class BybitCandleTimeConverter : JsonConverter<DateTime>
         JsonSerializer serializer)
     {
         var str = (string)reader.Value;
-        if (str == null || !decimal.TryParse(str, out var ts))
+        if (str == null || !decimal.TryParse(str, CultureInfo.InvariantCulture, out var ts))
         {
             return existingValue;
         }

--- a/QuantConnect.BybitBrokerage/Converters/BybitDecimalStringConverter.cs
+++ b/QuantConnect.BybitBrokerage/Converters/BybitDecimalStringConverter.cs
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 using System;
 using System.Globalization;
@@ -55,7 +55,6 @@ public class BybitDecimalStringConverter : JsonConverter<decimal>
     /// <param name="existingValue">The existing value of object being read.</param>
     /// <param name="hasExistingValue">The existing value has a value.</param>
     /// <param name="serializer">The calling serializer.</param>
-
     /// <returns>The object value.</returns>
     public override decimal ReadJson(JsonReader reader, Type objectType, decimal existingValue, bool hasExistingValue,
         JsonSerializer serializer)
@@ -65,16 +64,32 @@ public class BybitDecimalStringConverter : JsonConverter<decimal>
         {
             return dec;
         }
+
         if (val is double d)
         {
             return d.SafeDecimalCast();
         }
 
-        if (val is string str && decimal.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out var res))
+        if (val is string str && TryParse(str, out var res))
         {
             return res;
         }
 
+        if (val is not null)
+        {
+            // check other number types:
+            var strValue = Convert.ToString(val, CultureInfo.InvariantCulture);
+            if (TryParse(strValue, out var resAfterConversion))
+            {
+                return resAfterConversion;
+            }
+        }
+
         throw new Exception();
+    }
+
+    private static bool TryParse(string str, out decimal value)
+    {
+        return decimal.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
     }
 }

--- a/QuantConnect.BybitBrokerage/Converters/BybitDecimalStringConverter.cs
+++ b/QuantConnect.BybitBrokerage/Converters/BybitDecimalStringConverter.cs
@@ -70,7 +70,7 @@ public class BybitDecimalStringConverter : JsonConverter<decimal>
             return d.SafeDecimalCast();
         }
 
-        if (val is string str && decimal.TryParse(str, NumberStyles.Currency, CultureInfo.InvariantCulture, out var res))
+        if (val is string str && decimal.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out var res))
         {
             return res;
         }

--- a/QuantConnect.BybitBrokerage/Converters/BybitDecimalStringConverter.cs
+++ b/QuantConnect.BybitBrokerage/Converters/BybitDecimalStringConverter.cs
@@ -70,19 +70,14 @@ public class BybitDecimalStringConverter : JsonConverter<decimal>
             return d.SafeDecimalCast();
         }
 
+        if (val is not null && IsNumber(val))
+        {
+            return Convert.ToDecimal(val);
+        }
+
         if (val is string str && TryParse(str, out var res))
         {
             return res;
-        }
-
-        if (val is not null)
-        {
-            // check other number types:
-            var strValue = Convert.ToString(val, CultureInfo.InvariantCulture);
-            if (TryParse(strValue, out var resAfterConversion))
-            {
-                return resAfterConversion;
-            }
         }
 
         throw new Exception();
@@ -91,5 +86,20 @@ public class BybitDecimalStringConverter : JsonConverter<decimal>
     private static bool TryParse(string str, out decimal value)
     {
         return decimal.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
+    }
+
+    public static bool IsNumber(object value)
+    {
+        return value is sbyte
+               || value is byte
+               || value is short
+               || value is ushort
+               || value is int
+               || value is uint
+               || value is long
+               || value is ulong
+               || value is float
+               || value is double
+               || value is decimal;
     }
 }

--- a/QuantConnect.BybitBrokerage/Models/ByBitKLine.cs
+++ b/QuantConnect.BybitBrokerage/Models/ByBitKLine.cs
@@ -13,11 +13,15 @@
  * limitations under the License.
 */
 
+using Newtonsoft.Json;
+using QuantConnect.Brokerages.Bybit.Converters;
+
 namespace QuantConnect.Brokerages.Bybit.Models;
 
 /// <summary>
 /// KLine info
 /// </summary>
+[JsonConverter(typeof(ByBitKlineJsonConverter))]
 public class ByBitKLine
 {
     /// <summary>

--- a/QuantConnect.BybitBrokerage/Models/BybitTrade.cs
+++ b/QuantConnect.BybitBrokerage/Models/BybitTrade.cs
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 using System;
 using Newtonsoft.Json;
@@ -154,10 +154,4 @@ public class BybitTrade
     /// </summary>
     [JsonProperty("closedSize")]
     public decimal? ClosedQuantity { get; set; }
-
-    /// <summary>
-    /// The remaining qty not executed
-    /// </summary>
-    [JsonProperty("leavesQty")]
-    public decimal LeavesQuantity { get; set; }
 }

--- a/QuantConnect.BybitBrokerage/Models/BybitTrade.cs
+++ b/QuantConnect.BybitBrokerage/Models/BybitTrade.cs
@@ -154,4 +154,10 @@ public class BybitTrade
     /// </summary>
     [JsonProperty("closedSize")]
     public decimal? ClosedQuantity { get; set; }
+
+    /// <summary>
+    /// The remaining qty not executed
+    /// </summary>
+    [JsonProperty("leavesQty")]
+    public decimal LeavesQuantity { get; set; }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Enable concurrency
- Fix the Bybit filing issue

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Bybit Order execution issue
Example
```
Marget Buy BTCUSDT 0.0001

{
  "topic": "order",
  "id": "106619370_20000_2021269409",
  "creationTime": 1769798300234,
  "data": [
    {
      "category": "spot",
      "symbol": "BTCUSDT",
      "orderId": "2139617652191356928",
      "orderLinkId": "2139617652191356929",
      "blockTradeId": "",
      "side": "Buy",
      "positionIdx": 0,
      "orderStatus": "Filled",
      "cancelType": "UNKNOWN",
      "rejectReason": "EC_NoError",
      "timeInForce": "IOC",
      "isLeverage": "0",
      "price": "0",
      "qty": "8.2379800",
      "avgPrice": "82439.8",
      "leavesQty": "0",
      "leavesValue": "0.0764398",
      "cumExecQty": "0.000099",
      "cumExecValue": "8.1615402",
      "cumExecFee": "0.0000000891",
      "orderType": "Market",
      "stopOrderType": "",
      "orderIv": "",
      "triggerPrice": "0.0",
      "takeProfit": "0.0",
      "stopLoss": "0.0",
      "triggerBy": "",
      "tpTriggerBy": "",
      "slTriggerBy": "",
      "triggerDirection": 0,
      "placeType": "",
      "lastPriceOnCreated": "82439.3",
      "closeOnTrigger": false,
      "reduceOnly": false,
      "smpGroup": 0,
      "smpType": "None",
      "smpOrderId": "",
      "slLimitPrice": "0.0",
      "tpLimitPrice": "0.0",
      "marketUnit": "quoteCoin",
      "createdTime": "1769798300228",
      "updatedTime": "1769798300233",
      "feeCurrency": "BTC",
      "slippageTolerance": "",
      "slippageToleranceType": "UNKNOWN",
      "cumFeeDetail": {
        "BTC": "0.0000000891"
      }
    }
  ]
}
```
Based on the `cumExecQty` we can indicate when the order is acyually got Filled, even it's not exactly matched to initial order

Covers cases

```
Buy 0.004

ExecutionUpdate PartialFill 0.001
ExecutionUpdate PArtialFill 0.001
OrderUpdate Filled 0.00399
ExectuionUpdate PatialFill 0.00199 

Buy 0.004

ExecutionUpdate PartialFill 0.001
ExecutionUpdate PartialFill 0.001
ExectuionUpdate PatialFill 0.00199 
OrderUpdate Filled 0.00399
```

##### Performance Report

| Wave | OrderC ount | Total Time (ms) | Concurrency |
|------|-----------|-------------|-------------|
| 1 | 100 | 60852.99 | ▢ |
| 2 | 100 | 61452.75 | ▢ |
| 3 | 100 | 60879.68 | ▢ |
| 4 | 100 | 61172.49 | ▢ |
| 1 | 100 | 21020.04 | ✅ |
| 2 | 100 | 20193.15 | ✅ |
| 3 | 100 | 21804.99 | ✅ |
| 4 | 100 | 20789.07 | ✅ |

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on testnet
4 waves x 100 orders

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [x] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
